### PR TITLE
Adding Hide Attribute

### DIFF
--- a/client/src/components/Tile.tsx
+++ b/client/src/components/Tile.tsx
@@ -20,7 +20,9 @@ const Tile: React.FC<TileProps> = ({
   children,
   hide,
 }) => {
-  const tile = !hide ? (
+  if (hide) return <></>;
+
+  const tile = (
     <HStack px={2} textColor={disabled ? "gray.500" : undefined}>
       <TileImage imageUrl={imageUrl} imageAlt={imageAlt ?? header} />
       <VStack align="stretch" spacing={0.3}>
@@ -30,8 +32,6 @@ const Tile: React.FC<TileProps> = ({
         {children}
       </VStack>
     </HStack>
-  ) : (
-    <></>
   );
 
   return href ? (

--- a/client/src/components/Tile.tsx
+++ b/client/src/components/Tile.tsx
@@ -8,6 +8,7 @@ export interface TileProps {
   imageAlt?: string;
   href?: string;
   disabled?: boolean;
+  hide?: boolean;
 }
 
 const Tile: React.FC<TileProps> = ({
@@ -17,8 +18,9 @@ const Tile: React.FC<TileProps> = ({
   href,
   disabled,
   children,
+  hide,
 }) => {
-  const tile = (
+  const tile = !hide ? (
     <HStack px={2} textColor={disabled ? "gray.500" : undefined}>
       <TileImage imageUrl={imageUrl} imageAlt={imageAlt ?? header} />
       <VStack align="stretch" spacing={0.3}>
@@ -28,6 +30,8 @@ const Tile: React.FC<TileProps> = ({
         {children}
       </VStack>
     </HStack>
+  ) : (
+    <></>
   );
 
   return href ? (


### PR DESCRIPTION
Adding support for a `hide={boolean}` attribute for `<Tile>`, so tiles can be hidden without wrapping the entire tile logic in a conditional and preventing the use of hooks within most of the tile logic.