### PR TITLE
Quest Standardization

### DIFF
--- a/client/src/sections/quests/Level1.tsx
+++ b/client/src/sections/quests/Level1.tsx
@@ -1,15 +1,15 @@
 import Line from "../../components/Line";
 import Tile from "../../components/Tile";
-import { useQuestFinished } from "../../hooks/useQuest";
+import { Step, useQuestStep } from "../../hooks/useQuest";
 
 const Level1: React.FC = () => {
-  const completed = useQuestFinished("questM05Toot");
-  if (completed) return <></>;
+  const step = useQuestStep("questM05Toot");
   return (
     <Tile
       header="Toot Oriole"
       imageUrl="/images/otherimages/oriole.gif"
       href="/tutorial.php?action=toot"
+      hide={step === Step.FINISHED}
     >
       <Line>Visit the Toot Oriole.</Line>
     </Tile>

--- a/client/src/sections/quests/Level2.tsx
+++ b/client/src/sections/quests/Level2.tsx
@@ -1,33 +1,28 @@
 import Line from "../../components/Line";
 import QuestTile from "../../components/QuestTile";
-import useHave from "../../hooks/useHave";
-import { useQuestFinished, useQuestStarted } from "../../hooks/useQuest";
-import { $item } from "../../util/makeValue";
+import { atStep, Step, useQuestStep } from "../../hooks/useQuest";
 
 const Level2: React.FC = () => {
-  const started = useQuestStarted("questL02Larva");
-  const finished = useQuestFinished("questL02Larva");
-
-  const haveLarva = useHave($item`mosquito larva`);
-
-  if (finished) return <></>;
+  const step = useQuestStep("questL02Larva");
 
   return (
     <QuestTile
       header="Spooky Forest"
       imageUrl="/images/adventureimages/forest.gif"
-      href={started && !haveLarva ? "/woods.php" : "/council.php"}
+      href={atStep(step, [
+        [Step.UNSTARTED, "/council.php"],
+        [Step.STARTED, "/woods.php"],
+        [1, "/council.php"],
+        [Step.FINISHED, undefined],
+      ])}
       minLevel={2}
+      hide={step === Step.FINISHED}
     >
-      {started ? (
-        haveLarva ? (
-          <Line>Turn in larva to the Council.</Line>
-        ) : (
-          <Line>Adventure for mosquito larva.</Line>
-        )
-      ) : (
-        <Line>Visit Council to start quest.</Line>
-      )}
+      {atStep(step, [
+        [Step.UNSTARTED, <Line>Visit Council to start quest.</Line>],
+        [Step.STARTED, <Line>Adventure for mosquito larva.</Line>],
+        [1, <Line>Turn in larva to the Council.</Line>],
+      ])}
     </QuestTile>
   );
 };

--- a/client/src/sections/quests/Level3.tsx
+++ b/client/src/sections/quests/Level3.tsx
@@ -32,6 +32,7 @@ const Level3: React.FC = () => {
         [Step.FINISHED, undefined],
       ])}
       minLevel={3}
+      hide={step === Step.FINISHED}
     >
       {atStep(step, [
         [Step.UNSTARTED, <Line>Visit Council to start quest.</Line>],

--- a/client/src/sections/quests/Level4.tsx
+++ b/client/src/sections/quests/Level4.tsx
@@ -9,8 +9,6 @@ const Level4: React.FC = () => {
   const bodyguards: { turnsSpent?: number } =
     useToLocation("The Boss Bat's Lair") ?? {};
 
-  if (step === Step.FINISHED) return <></>;
-
   return (
     <QuestTile
       header="Bat Hole"
@@ -21,6 +19,7 @@ const Level4: React.FC = () => {
         [Step.FINISHED, undefined],
       ])}
       minLevel={4}
+      hide={step === Step.FINISHED}
     >
       {atStep(step, [
         [Step.UNSTARTED, <Line>Visit Council to start quest.</Line>],

--- a/client/src/sections/quests/Level8.tsx
+++ b/client/src/sections/quests/Level8.tsx
@@ -29,8 +29,6 @@ const Level8: React.FC = () => {
 
   const yetiCount = useToLocation("Mist-Shrouded Peak")?.turnsSpent ?? 0;
 
-  if (step === Step.FINISHED) return <></>;
-
   // TODO: Find image URL.
   return (
     <QuestTile
@@ -45,7 +43,9 @@ const Level8: React.FC = () => {
         [Step.FINISHED, undefined],
       ])}
       minLevel={8}
+      hide={step === Step.FINISHED}
     >
+      <Line>step = {step}</Line>
       {atStep(step, [
         [Step.UNSTARTED, <Line>Visit Council to start quest.</Line>],
         [Step.STARTED, <Line>Visit the Trapper to get your assignment.</Line>],

--- a/client/src/sections/quests/Level8.tsx
+++ b/client/src/sections/quests/Level8.tsx
@@ -45,7 +45,6 @@ const Level8: React.FC = () => {
       minLevel={8}
       hide={step === Step.FINISHED}
     >
-      <Line>step = {step}</Line>
       {atStep(step, [
         [Step.UNSTARTED, <Line>Visit Council to start quest.</Line>],
         [Step.STARTED, <Line>Visit the Trapper to get your assignment.</Line>],

--- a/client/src/sections/resources/CosmicBowlingBall.tsx
+++ b/client/src/sections/resources/CosmicBowlingBall.tsx
@@ -65,6 +65,11 @@ const CosmicBowlingBall = () => {
           Your Bowling Ball will return in {plural(returnCombats, "turn")}.{" "}
         </Line>
       )}
+      {returnCombats === 0 && (
+        <Line>
+          Your Bowling Ball will return at the start of the next combat!
+        </Line>
+      )}
     </Tile>
   );
 };


### PR DESCRIPTION
I don't know if this is desirable or not, but I went through changed the level 1/2 quests over to using the `useQuestStep` function so that all of them were structured similarly. I think it makes them more readable and requires fewer imports.

I also swapped the quest over to utilizing the `hide` attribute.

Finally, snuck a tiny fix into the cosmic bowling ball - when the ball was set to return on the next combat the tile wouldn't have any `Line`s, just the header and image.

