### PR TITLE
Emotion Chip support

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@chakra-ui/react": "^1.7.4",
+    "@chakra-ui/icons": "^1.1.2",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
     "@testing-library/jest-dom": "^5.16.1",

--- a/client/src/components/Chevrons.tsx
+++ b/client/src/components/Chevrons.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { ChevronRightIcon } from "@chakra-ui/icons";
+import { HStack } from "@chakra-ui/react";
+
+interface ChevronProps {
+  usesLeft: number;
+  totalUses: number;
+}
+
+/**
+ * Generate fading chevrons to describe # of a resource left out of total casts
+ * @returns Three <ListIcon> objects colored by availability of the resource
+ * @param usesLeft How many casts/uses you have left of the resource
+ * @param totalUses Total number of uses the users has
+ */
+const Chevrons: React.FC<ChevronProps> = ({ usesLeft, totalUses }) => {
+  return (
+    <HStack display="inline-flex" verticalAlign="middle" spacing={-2.5}>
+      {new Array(totalUses).fill(null).map((_, index) => (
+        <ChevronRightIcon // I tried a few types of icons. This was the best, for now.
+          key={index}
+          color={index < usesLeft ? "black" : "gray.400"}
+        />
+      ))}
+    </HStack>
+  );
+};
+
+export default Chevrons;

--- a/client/src/sections/ResourceSection.tsx
+++ b/client/src/sections/ResourceSection.tsx
@@ -8,12 +8,14 @@ import PowerfulGlove from "./resources/PowerfulGlove";
 import BackupCamera from "./resources/BackupCamera";
 import CosmicBowlingBall from "./resources/CosmicBowlingBall";
 import IndustrialFireExtinguisher from "./resources/IndustrialFireExtinguisher";
+import EmotionChip from "./resources/EmotionChip";
 
 const ResourceSection = () => (
   <Section name="Resources">
     <FreeFights />
     <BackupCamera />
     <ColdMedicineCabinet />
+    <EmotionChip />
     <CosmicBowlingBall />
     <PowerfulGlove />
     <CursedMagnifyingGlass />

--- a/client/src/sections/resources/EmotionChip.tsx
+++ b/client/src/sections/resources/EmotionChip.tsx
@@ -6,6 +6,7 @@ import useGet from "../../hooks/useGet";
 import useHave from "../../hooks/useHave";
 import { $skill } from "../../util/makeValue";
 import { plural } from "../../util/text";
+import { useGetProperty } from "../../hooks/useCall";
 
 /**
  * Generate fading chevrons to describe # of a resource left out of total casts
@@ -16,11 +17,14 @@ import { plural } from "../../util/text";
 export function generateChevrons(usesLeft: number, totalUses: number) {
   let output = [];
 
+  /** One small issue within this Chevron function... -- it doesn't actually
+   *    align if you aren't doing a lot of things with the same# of casts. I
+   *    do not think this is trivially fixable, but something to know.*/
   for (var use = 1; use <= totalUses; use++) {
     output.push(
       <ListIcon
-        as={ChevronRightIcon}
-        mr={use === totalUses ? "0" : "-2.5"}
+        as={ChevronRightIcon} // I tried a few types of icons. This was the best, for now.
+        mr={use === totalUses ? "0" : "-2.5"} // This uses negative margin to create the overlap effect on all but the last one.
         color={usesLeft >= use ? "black" : "gray.400"}
       />
     );
@@ -36,7 +40,7 @@ export function generateChevrons(usesLeft: number, totalUses: number) {
 
 const EmotionChip = () => {
   const playerIsChipped = useHave($skill`Emotionally Chipped`);
-  const nostalgiaMonster = useGet("lastCopyableMonster")?.name;
+  const nostalgiaMonster = useGetProperty("lastCopyableMonster");
 
   // Associating skills with the # remaining of each of them.
   const emoChipSkills = {

--- a/client/src/sections/resources/EmotionChip.tsx
+++ b/client/src/sections/resources/EmotionChip.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { ChevronRightIcon } from "@chakra-ui/icons";
-import { HStack, List, ListIcon, ListItem } from "@chakra-ui/react";
+import { List, ListIcon, ListItem } from "@chakra-ui/react";
+import Chevrons from "../../components/Chevrons";
 import Line from "../../components/Line";
 import Tile from "../../components/Tile";
 import { useGetProperty } from "../../hooks/useCall";
@@ -8,30 +8,6 @@ import useGet from "../../hooks/useGet";
 import useHave from "../../hooks/useHave";
 import { $skill } from "../../util/makeValue";
 import { plural } from "../../util/text";
-
-interface ChevronProps {
-  usesLeft: number;
-  totalUses: number;
-}
-
-/**
- * Generate fading chevrons to describe # of a resource left out of total casts
- * @returns Three <ListIcon> objects colored by availability of the resource
- * @param usesLeft How many casts/uses you have left of the resource
- * @param totalUses Total number of uses the users has
- */
-const Chevrons: React.FC<ChevronProps> = ({ usesLeft, totalUses }) => {
-  return (
-    <HStack display="inline-flex" verticalAlign="middle" spacing={-2.5}>
-      {new Array(totalUses).fill(null).map((_, index) => (
-        <ChevronRightIcon // I tried a few types of icons. This was the best, for now.
-          key={index}
-          color={index < usesLeft ? "black" : "gray.400"}
-        />
-      ))}
-    </HStack>
-  );
-};
 
 /**
  * Summarizes availability of buffs & nostalgia; no recommendations, and Hatred is covered in banishes.

--- a/client/src/sections/resources/EmotionChip.tsx
+++ b/client/src/sections/resources/EmotionChip.tsx
@@ -1,0 +1,80 @@
+import { List, ListItem, ListIcon } from "@chakra-ui/react";
+import { ChevronRightIcon } from "@chakra-ui/icons";
+import Line from "../../components/Line";
+import Tile from "../../components/Tile";
+import useGet from "../../hooks/useGet";
+import useHave from "../../hooks/useHave";
+import { $skill } from "../../util/makeValue";
+import { plural } from "../../util/text";
+
+/**
+ * Generate fading chevrons to describe # of a resource left out of total casts
+ * @returns Three <ListIcon> objects colored by availability of the resource
+ * @param usesLeft How many casts/uses you have left of the resource
+ * @param totalUses Total number of uses the users has
+ */
+export function generateChevrons(usesLeft: number, totalUses: number) {
+  let output = [];
+
+  for (var use = 1; use <= totalUses; use++) {
+    output.push(
+      <ListIcon
+        as={ChevronRightIcon}
+        mr={use === totalUses ? "0" : "-2.5"}
+        color={usesLeft >= use ? "black" : "gray.400"}
+      />
+    );
+  }
+
+  return output;
+}
+
+/**
+ * Summarizes availability of buffs & nostalgia; no recommendations, and Hatred is covered in banishes.
+ * @returns A tile describing Emotion Chip skills (except Hatred!)
+ */
+
+const EmotionChip = () => {
+  const playerIsChipped = useHave($skill`Emotionally Chipped`);
+  const nostalgiaMonster = useGet("lastCopyableMonster")?.name;
+
+  // Associating skills with the # remaining of each of them.
+  const emoChipSkills = {
+    "Feel Envy": 3 - useGet("_feelEnvyUsed"),
+    "Feel Excitement": 3 - useGet("_feelExcitementUsed"),
+    "Feel Lonely": 3 - useGet("_feelLonelyUsed"),
+    "Feel Nostalgic": 3 - useGet("_feelNostalgicUsed"),
+    "Feel Pride": 3 - useGet("_feelPrideUsed"),
+    "Feel Peaceful": 3 - useGet("_feelPeacefulUsed"),
+  };
+
+  // Turning the skills into list items w/ chevron coloring based on # left
+  let listItems = [];
+  for (const [skillName, casts] of Object.entries(emoChipSkills)) {
+    if (casts > 0) {
+      listItems.push(
+        <ListItem pl="1">
+          {generateChevrons(casts, 3)} {plural(casts, "cast")} of {skillName}{" "}
+          {skillName === "Feel Nostalgic" ? `(${nostalgiaMonster})` : ""}
+        </ListItem>
+      );
+    }
+  }
+
+  // To-Do list for this tile:
+  //   - Determine if we actually want Feel Lost visualized. I think not!
+  //   - My lean is to not include hatred and leave it for the banish tile I'm making.
+  return (
+    <Tile
+      header="Emotion Chip"
+      imageUrl="/images/itemimages/emochip1.gif"
+      hide={!playerIsChipped}
+    >
+      <Line>
+        <List stylePosition="inside">{listItems}</List>
+      </Line>
+    </Tile>
+  );
+};
+
+export default EmotionChip;

--- a/client/src/sections/resources/EmotionChip.tsx
+++ b/client/src/sections/resources/EmotionChip.tsx
@@ -53,18 +53,17 @@ const EmotionChip = () => {
   };
 
   // Turning the skills into list items w/ chevron coloring based on # left
-  const listItems = [];
-  for (const [skillName, casts] of Object.entries(emoChipSkills)) {
-    if (casts > 0) {
-      listItems.push(
-        <ListItem pl="1">
-          <ListIcon as={Chevrons} usesLeft={casts} totalUses={3} />
-          {plural(casts, "cast")} of {skillName}{" "}
-          {skillName === "Feel Nostalgic" ? `(${nostalgiaMonster})` : ""}
-        </ListItem>
-      );
-    }
-  }
+  const listItems = Object.entries(emoChipSkills).map(function (entry) {
+    const skillName = entry[0];
+    const casts = entry[1];
+    return (
+      <ListItem pl="1">
+        <ListIcon as={Chevrons} usesLeft={casts} totalUses={3} />
+        {plural(casts, "cast")} of {skillName}{" "}
+        {skillName === "Feel Nostalgic" ? `(${nostalgiaMonster})` : ""}
+      </ListItem>
+    );
+  });
 
   // To-Do list for this tile:
   //   - Determine if we actually want Feel Lost visualized. I think not!

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1229,6 +1229,14 @@
   dependencies:
     "@chakra-ui/utils" "1.9.1"
 
+"@chakra-ui/icons@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/icons/-/icons-1.1.2.tgz#2a23a449ac553327b156cd60b31dfe22320c1c53"
+  integrity sha512-ixrhJhgF6nQOskY4zIsFG8qSiuiUjaKCR+Xmy8MCuGW+/kbztqkzPeDOc0Ypq3JUtH44mU1dP9LjQzxRIviSCA==
+  dependencies:
+    "@chakra-ui/icon" "2.0.0"
+    "@types/react" "^17.0.15"
+
 "@chakra-ui/image@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@chakra-ui/image/-/image-1.1.2.tgz#257eb0d6a3759301066e7b1d68cc3e3b0c36c204"
@@ -2486,7 +2494,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.0.38":
+"@types/react@*", "@types/react@^17.0.15", "@types/react@^17.0.38":
   version "17.0.38"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.38.tgz#f24249fefd89357d5fa71f739a686b8d7c7202bd"
   integrity sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==


### PR DESCRIPTION
resolves #30 

![image](https://user-images.githubusercontent.com/8014761/150625670-711b1f41-35e5-40ab-92dc-65b419fb76c7.png)

the tile itself, after a lot of struggling to get the chevrons visually right, is actually quite simple. i probably should've used a map instead of that for loop but my very first attempt to write it as a map did not work and i was tired. i was thinking about combining this with the banish tileset but i think it probably stands on its own perfectly fine.

**WARNING:** this PR changes the client's package.json to add react icons as a dependency. once merged, you will need to go back into yorick/client and re-run yarn install. should work fine after that tho.