### PR TITLE
Remove unnecessary hooks from quests

### DIFF
--- a/client/src/sections/quests/Level3.tsx
+++ b/client/src/sections/quests/Level3.tsx
@@ -1,19 +1,19 @@
 import Line from "../../components/Line";
 import QuestTile from "../../components/QuestTile";
-import { useNumericModifier } from "../../hooks/useCall";
 import { atStep, Step, useQuestStep } from "../../hooks/useQuest";
+import { numericModifier } from "../../kolmafia/functions";
 import { commaAnd } from "../../util/text";
 
 const Level3: React.FC = () => {
   const step = useQuestStep("questL03Rat");
 
-  const cold = useNumericModifier("Cold Damage") ?? 0;
-  const hot = useNumericModifier("Hot Damage") ?? 0;
-  const stench = useNumericModifier("Stench Damage") ?? 0;
-  const spooky = useNumericModifier("Spooky Damage") ?? 0;
-  const sleaze = useNumericModifier("Sleaze Damage") ?? 0;
-  const combat = useNumericModifier("Combat Rate") ?? 0;
-  const ml = useNumericModifier("Monster Level") ?? 0;
+  const cold = numericModifier("Cold Damage") ?? 0;
+  const hot = numericModifier("Hot Damage") ?? 0;
+  const stench = numericModifier("Stench Damage") ?? 0;
+  const spooky = numericModifier("Spooky Damage") ?? 0;
+  const sleaze = numericModifier("Sleaze Damage") ?? 0;
+  const combat = numericModifier("Combat Rate") ?? 0;
+  const ml = numericModifier("Monster Level") ?? 0;
 
   const all = Object.entries({ cold, hot, stench, spooky, sleaze });
   const needed = all.filter(([, value]) => value < 20);

--- a/client/src/sections/quests/Level3.tsx
+++ b/client/src/sections/quests/Level3.tsx
@@ -7,13 +7,13 @@ import { commaAnd } from "../../util/text";
 const Level3: React.FC = () => {
   const step = useQuestStep("questL03Rat");
 
-  const cold = numericModifier("Cold Damage") ?? 0;
-  const hot = numericModifier("Hot Damage") ?? 0;
-  const stench = numericModifier("Stench Damage") ?? 0;
-  const spooky = numericModifier("Spooky Damage") ?? 0;
-  const sleaze = numericModifier("Sleaze Damage") ?? 0;
-  const combat = numericModifier("Combat Rate") ?? 0;
-  const ml = numericModifier("Monster Level") ?? 0;
+  const cold = numericModifier("Cold Damage");
+  const hot = numericModifier("Hot Damage");
+  const stench = numericModifier("Stench Damage");
+  const spooky = numericModifier("Spooky Damage");
+  const sleaze = numericModifier("Sleaze Damage");
+  const combat = numericModifier("Combat Rate");
+  const ml = numericModifier("Monster Level");
 
   const all = Object.entries({ cold, hot, stench, spooky, sleaze });
   const needed = all.filter(([, value]) => value < 20);

--- a/client/src/sections/quests/Level4.tsx
+++ b/client/src/sections/quests/Level4.tsx
@@ -1,13 +1,12 @@
+import { $location } from "libram";
 import Line from "../../components/Line";
 import QuestTile from "../../components/QuestTile";
-import { useToLocation } from "../../hooks/useCall";
 import { atStep, Step, useQuestStep } from "../../hooks/useQuest";
 import { plural } from "../../util/text";
 
 const Level4: React.FC = () => {
   const step = useQuestStep("questL04Bat");
-  const bodyguards: { turnsSpent?: number } =
-    useToLocation("The Boss Bat's Lair") ?? {};
+  const bodyguards = $location`The Boss Bat's Lair`.turnsSpent ?? 0;
 
   return (
     <QuestTile
@@ -34,8 +33,7 @@ const Level4: React.FC = () => {
           3,
           <Line>
             Face the fearsome Boss Bat in his lair! You must fight at least{" "}
-            {Math.max(0, 4 - (bodyguards.turnsSpent ?? 0))} bodyguards to find
-            him.
+            {Math.max(0, 4 - bodyguards)} bodyguards to find him.
           </Line>,
         ],
         [4, <Line>Return to the council with news of your defeated foe.</Line>],

--- a/client/src/sections/quests/Level4.tsx
+++ b/client/src/sections/quests/Level4.tsx
@@ -6,7 +6,7 @@ import { plural } from "../../util/text";
 
 const Level4: React.FC = () => {
   const step = useQuestStep("questL04Bat");
-  const bodyguards = $location`The Boss Bat's Lair`.turnsSpent ?? 0;
+  const bodyguards = $location`The Boss Bat's Lair`.turnsSpent;
 
   return (
     <QuestTile

--- a/client/src/sections/quests/Level5.tsx
+++ b/client/src/sections/quests/Level5.tsx
@@ -1,25 +1,22 @@
+import { $effect, $item, $location, get, have } from "libram";
 import Line from "../../components/Line";
 import QuestTile from "../../components/QuestTile";
-import { useHaveOutfit, useIsWearingOutfit } from "../../hooks/useCall";
-import useFull from "../../hooks/useFull";
-import useGet from "../../hooks/useGet";
-import useHave from "../../hooks/useHave";
 import { atStep, Step, useQuestStep } from "../../hooks/useQuest";
+import { haveOutfit, isWearingOutfit } from "../../kolmafia/functions";
 import { inventory } from "../../util/links";
-import { $effect, $item, $location } from "../../util/makeValue";
 import { plural } from "../../util/text";
 
 const Level5: React.FC = () => {
   const step = useQuestStep("questL05Goblin");
-  const turnsSpent =
-    useFull($location`The Outskirts of Cobb's Knob`)?.turnsSpent ?? 0;
-  const haveKey = useHave($item`Knob Goblin encryption key`);
-  const haveOutfit = useHaveOutfit("Knob Goblin Harem Girl Disguise");
-  const havePerfume = useHave($effect`Knob Goblin Perfume`);
-  const equippedOutfit = useIsWearingOutfit("Knob Goblin Harem Girl Disguise");
-  const haveFireExtinguisher = useHave($item`industrial fire extinguisher`);
-  const fireExtinguisherCharge = useGet("_fireExtinguisherCharge");
-  const haremExtinguished = useGet("fireExtinguisherHaremUsed");
+
+  const turnsSpent = $location`The Outskirts of Cobb's Knob`.turnsSpent ?? 0;
+  const haveKey = have($item`Knob Goblin encryption key`);
+  const outfit = haveOutfit("Knob Goblin Harem Girl Disguise");
+  const havePerfume = have($effect`Knob Goblin Perfume`);
+  const equippedOutfit = isWearingOutfit("Knob Goblin Harem Girl Disguise");
+  const haveFireExtinguisher = have($item`industrial fire extinguisher`);
+  const fireExtinguisherCharge = get("_fireExtinguisherCharge");
+  const haremExtinguished = get("fireExtinguisherHaremUsed");
 
   return (
     <QuestTile
@@ -46,7 +43,7 @@ const Level5: React.FC = () => {
           ],
           [
             1,
-            !haveOutfit ? (
+            !outfit ? (
               <>
                 <Line>Acquire the Harem Girl Disguise.</Line>
                 {haveFireExtinguisher &&

--- a/client/src/sections/quests/Level5.tsx
+++ b/client/src/sections/quests/Level5.tsx
@@ -9,7 +9,7 @@ import { plural } from "../../util/text";
 const Level5: React.FC = () => {
   const step = useQuestStep("questL05Goblin");
 
-  const turnsSpent = $location`The Outskirts of Cobb's Knob`.turnsSpent ?? 0;
+  const turnsSpent = $location`The Outskirts of Cobb's Knob`.turnsSpent;
   const haveKey = have($item`Knob Goblin encryption key`);
   const outfit = haveOutfit("Knob Goblin Harem Girl Disguise");
   const havePerfume = have($effect`Knob Goblin Perfume`);

--- a/client/src/sections/quests/Level8.tsx
+++ b/client/src/sections/quests/Level8.tsx
@@ -12,7 +12,7 @@ const Level8: React.FC = () => {
   const step = useQuestStep("questL08Trapper");
 
   const goatCheese = itemAmount($item`goat cheese`) ?? 0;
-  const oreType = get("trapperOre");
+  const oreType = get("trapperOre", "none");
   const ore = itemAmount(toItem(oreType)) ?? 0;
   const faxLikes = useFaxLikes();
 

--- a/client/src/sections/quests/Level8.tsx
+++ b/client/src/sections/quests/Level8.tsx
@@ -11,9 +11,9 @@ const TRAPPER_URL = "/place.php?whichplace=mclargehuge&action=trappercabin";
 const Level8: React.FC = () => {
   const step = useQuestStep("questL08Trapper");
 
-  const goatCheese = itemAmount($item`goat cheese`) ?? 0;
+  const goatCheese = itemAmount($item`goat cheese`);
   const oreType = get("trapperOre", "none");
-  const ore = itemAmount(toItem(oreType)) ?? 0;
+  const ore = oreType !== "none" ? itemAmount(toItem(oreType)) : 0;
   const faxLikes = useFaxLikes();
 
   const rope = have($item`ninja rope`);
@@ -21,9 +21,9 @@ const Level8: React.FC = () => {
   const carabiner = have($item`ninja carabiner`);
   const ninjaCount = (rope ? 1 : 0) + (crampons ? 1 : 0) + (carabiner ? 1 : 0);
 
-  const coldRes = numericModifier("Cold Resistance") ?? 0;
+  const coldRes = numericModifier("Cold Resistance");
 
-  const yetiCount = $location`Mist-Shrouded Peak`.turnsSpent ?? 0;
+  const yetiCount = $location`Mist-Shrouded Peak`.turnsSpent;
 
   // TODO: Find image URL.
   return (

--- a/client/src/sections/quests/Level8.tsx
+++ b/client/src/sections/quests/Level8.tsx
@@ -1,13 +1,8 @@
-import { $item, have } from "libram";
+import { $item, $location, get, have } from "libram";
 import Line from "../../components/Line";
 import QuestTile from "../../components/QuestTile";
-import {
-  useItemAmount,
-  useNumericModifier,
-  useToLocation,
-} from "../../hooks/useCall";
-import useGet from "../../hooks/useGet";
 import { atStep, Step, useQuestStep } from "../../hooks/useQuest";
+import { itemAmount, numericModifier, toItem } from "../../kolmafia/functions";
 import { commaAnd, commaOr, plural, truthy } from "../../util/text";
 import useFaxLikes from "../../util/useFaxLikes";
 
@@ -16,9 +11,9 @@ const TRAPPER_URL = "/place.php?whichplace=mclargehuge&action=trappercabin";
 const Level8: React.FC = () => {
   const step = useQuestStep("questL08Trapper");
 
-  const goatCheese = useItemAmount($item`goat cheese`) ?? 0;
-  const oreType = useGet("trapperOre", "none");
-  const ore = useItemAmount($item`${oreType}`) ?? 0;
+  const goatCheese = itemAmount($item`goat cheese`) ?? 0;
+  const oreType = get("trapperOre");
+  const ore = itemAmount(toItem(oreType)) ?? 0;
   const faxLikes = useFaxLikes();
 
   const rope = have($item`ninja rope`);
@@ -26,9 +21,9 @@ const Level8: React.FC = () => {
   const carabiner = have($item`ninja carabiner`);
   const ninjaCount = (rope ? 1 : 0) + (crampons ? 1 : 0) + (carabiner ? 1 : 0);
 
-  const coldRes = useNumericModifier("Cold Resistance") ?? 0;
+  const coldRes = numericModifier("Cold Resistance") ?? 0;
 
-  const yetiCount = useToLocation("Mist-Shrouded Peak")?.turnsSpent ?? 0;
+  const yetiCount = $location`Mist-Shrouded Peak`.turnsSpent ?? 0;
 
   // TODO: Find image URL.
   return (


### PR DESCRIPTION
I tested this pretty thoroughly by stepping through each stage of the associated quests and didn't see any change in behavior.

My understanding is that for quest tiles, in general we're really only using the quest step stuff from the hooks.