### PR TITLE
basic sweaty

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -25,7 +25,7 @@
     "eslint-config-react-app": "^7.0.0",
     "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-plugin-import": "^2.25.4",
-    "eslint-plugin-libram": "^0.2.9",
+    "eslint-plugin-libram": "^0.2.13",
     "eslint-plugin-unused-imports": "^2.0.0",
     "framer-motion": "^5",
     "libram": "^0.6.5",

--- a/client/src/sections/ResourceSection.tsx
+++ b/client/src/sections/ResourceSection.tsx
@@ -6,6 +6,7 @@ import CommerceGhost from "./resources/CommerceGhost";
 import CosmicBowlingBall from "./resources/CosmicBowlingBall";
 import CursedMagnifyingGlass from "./resources/CursedMagnifyingGlass";
 import DaylightShavingsHelmet from "./resources/DaylightShavingsHelmet";
+import DesignerSweatpants from "./resources/DesignerSweatpants";
 import EmotionChip from "./resources/EmotionChip";
 import FreeFights from "./resources/FreeFights";
 import IndustrialFireExtinguisher from "./resources/IndustrialFireExtinguisher";
@@ -28,6 +29,7 @@ const ResourceSection = () => (
     <UndergroundFireworksShop />
     <CommerceGhost />
     <IndustrialFireExtinguisher />
+    <DesignerSweatpants />
   </Section>
 );
 

--- a/client/src/sections/resources/DesignerSweatpants.tsx
+++ b/client/src/sections/resources/DesignerSweatpants.tsx
@@ -1,0 +1,32 @@
+import { $item, get, have } from "libram";
+import Line from "../../components/Line";
+import Tile from "../../components/Tile";
+
+const DesignerSweatpants = () => {
+  const sweat = parseInt(get("sweat"));
+  const liverCleansRemaining = 3 - parseInt(get("_sweatOutSomeBoozeUsed"));
+  return (
+    <Tile
+      header="Designer Sweatpants"
+      imageUrl="/images/itemimages/sweats.gif"
+      linkedContent={$item`designer sweatpants`}
+      hide={!have($item`designer sweatpants`)}
+    >
+      <Line>💦 You have {sweat} sweat. 💦</Line>
+      {liverCleansRemaining > 0 && sweat >= 25 && (
+        <Line>
+          Use Sweat Out Some Booze to recover 1 liver space -{" "}
+          {liverCleansRemaining} {liverCleansRemaining > 1 ? "uses" : "use"}{" "}
+          remaining.
+        </Line>
+      )}
+      {liverCleansRemaining === 0 && sweat > 90 && (
+        <Line>
+          You have a lot of sweat, maybe restore some MP or make sweatade.
+        </Line>
+      )}
+    </Tile>
+  );
+};
+
+export default DesignerSweatpants;

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4645,10 +4645,10 @@ eslint-plugin-jsx-a11y@^6.5.1:
     language-tags "^1.0.5"
     minimatch "^3.0.4"
 
-eslint-plugin-libram@^0.2.9:
-  version "0.2.9"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-libram/-/eslint-plugin-libram-0.2.9.tgz#088bfca00b64c564c2c051069d064a97af8fbe84"
-  integrity sha512-MLNW0/Qlx61Jnn5LOnvNRk23c4/0GL26zWNjx/2CvJf8UUuHTJ5ORNNn13pqYgXNNrDA2/+V/6O3JLtwMlKXBw==
+eslint-plugin-libram@^0.2.13:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-libram/-/eslint-plugin-libram-0.2.13.tgz#27f3d7c872275b2e265e2898777dd17c91ea359b"
+  integrity sha512-g2TITtQIIxhKUa8L2gX4Dfd2mM6tJnBPXGPKc6W16uS3AOc2HcjYMAoQ7Gf9C90WtRkYaUXpAaLrkrAwa2Ri5g==
   dependencies:
     html-entities "^2.3.2"
     requireindex "~1.1.0"


### PR DESCRIPTION
I'd like to check against the telescope elements to determine if we need fat sleaze damage, but that can come after libram support for parsing telescope properties which are a bit messy. There are some `parseInt()`s that can be removed when libram's get supports sweatpants properties.